### PR TITLE
Detect Meteor Node version for Dockerfile.

### DIFF
--- a/dockerfile.js
+++ b/dockerfile.js
@@ -1,5 +1,9 @@
+const { execSync } = require('child_process')
+
+const nodeVersion = execSync('meteor node -v').slice(1);
+
 const dockerFile = `
-FROM node:8.15.1
+FROM node:${nodeVersion}
 
 COPY programs/server/package.json /usr/src/app/programs/server/package.json
 WORKDIR /usr/src/app/programs/server


### PR DESCRIPTION
The Dockerfile has the Node version hardcoded to `8.15.1`. The latest recommended version of Meteor is 8.17.0. Meteor 1.9 has also just been released, which uses Node 12.14.0.

I figured instead of having to constantly update the Dockerfile with each release just let the deployment script figure out what Node version the installed Meteor uses, and then use that in the Dockerfile.