### PR TITLE
Add -s option to configure meteor settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ This program is designed to be run inside of a MeteorJS project and will do the 
     -b DIR             Overwrite BUILD_DIR
     -e VAR=value       Environment variables to set on the deployed heroku instance.
     -E `FILE`          Env file to be read for environment variables to be set.
+    -s `FILE`          Meteor settings file to be set as METEOR_SETTINGS environment variable.
 
   Commands:
     []  By default deploys a MeteorJS application to heroku.
@@ -82,4 +83,8 @@ This program is designed to be run inside of a MeteorJS project and will do the 
   – Deploy using env file
 
     $ meteor-hero -E prod.env
+
+  – Deploy with Meteor settings file
+
+    $ meteor-hero -s settings.json
 ```

--- a/commands/help.js
+++ b/commands/help.js
@@ -32,6 +32,9 @@ function help () {
     -E ${bold.underline(
     `FILE`
   )}              Env file to be read for environment variables to be set.
+    -s ${bold.underline(
+    `FILE`
+  )}              Meteor settings file to be set as METEOR_SETTINGS environment variable
 
   ${grey(`Commands:`)}
     []  By default deploys a MeteorJS application to heroku.
@@ -49,6 +52,9 @@ function help () {
 
     ${cyan(`$ meteor-hero -E prod.env`)}
 
+  ${grey(`–`)} Deploy with Meteor settings file
+
+    ${cyan(`$ meteor-hero -s settings.json`)}
 `)
   // .slice(1, -1)
 }

--- a/commands/newDeploy.js
+++ b/commands/newDeploy.js
@@ -1,7 +1,7 @@
 const fs = require('fs')
 const tar = require('tar')
 const { execSync } = require('child_process')
-const { explain, meteorBuildDir, logger, objToEnvStr, clearBuildFolder } = require('../helpers')
+const { explain, meteorBuildDir, logger, objToEnvStr, clearBuildFolder, getMeteorSettingsAsString } = require('../helpers')
 const { herokuCreate } = require('../commandHelpers')
 const dockerFile = require('../dockerfile')
 const dotenv = require('dotenv')
@@ -80,9 +80,15 @@ function getCustomEnv (args) {
       )
     : {}
 
+  // Meteor settings
+  const meteorSettings = args['s']
+    ? { METEOR_SETTINGS: getMeteorSettingsAsString(args['s']) }
+    : {};
+
   return {
     ...envFileEnv,
-    ...envArgsEnv
+    ...envArgsEnv,
+    ...meteorSettings
   }
 }
 

--- a/helpers.js
+++ b/helpers.js
@@ -1,3 +1,4 @@
+const { execSync } = require('child_process')
 const os = require('os')
 const yargs = require('yargs')
 const del = require('del')
@@ -43,10 +44,18 @@ function explain (explanation) {
   process.exit(1)
 }
 
+function getMeteorSettingsAsString(fileName) {
+  // Remove all line breaks
+  const json = execSync(`cat ${fileName}`).toString().trim().replace(/\t|\r?\n|\r/g, "");
+  // Wrap in quotes so JSON string can work with heroku config:set
+  return `'${json}'`;
+}
+
 module.exports = {
   args,
   clearBuildFolder,
   explain,
+  getMeteorSettingsAsString,
   logger,
   meteorBuildDir,
   objToEnvStr

--- a/helpers.spec.js
+++ b/helpers.spec.js
@@ -3,6 +3,13 @@
 const delMock = jest.fn()
 jest.doMock('del', () => delMock)
 jest.doMock('os', () => ({ homedir: () => '$HOMEDIR' }))
+jest.doMock('child_process', () => ({ execSync: (_) =>
+  `{
+    "a": {
+      "b": 1
+    }
+  }`
+}));
 
 process.argv = [ 'node', 'meteor-hero', '-e', 'something', '-e', 'anotherarg' ]
 
@@ -12,7 +19,8 @@ const {
   logger,
   objToEnvStr,
   meteorBuildDir,
-  clearBuildFolder
+  clearBuildFolder,
+  getMeteorSettingsAsString,
 } = require('./helpers')
 
 it('args', () => {
@@ -63,3 +71,9 @@ describe('meteorBuildDir', () => {
   })
 })
 
+describe('getMeteorSettingsAsString', () => {
+  it('trims line breaks and wraps in single quotes', () => {
+    console.log(getMeteorSettingsAsString());
+    expect(getMeteorSettingsAsString()).toBe(`'{    \"a\": {      \"b\": 1    }  }'`);
+  })
+})


### PR DESCRIPTION
Adds an option to allow the user to provide their Meteor settings json file to automatically configure a `METEOR_SETTINGS` environment variable on Heroku.

Ex: `meteor-hero -s settings.json`